### PR TITLE
Snap: Fix license top-level property

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: remote-touchpad
-# WORKAROUND: Snapcraft doesn't accept GPL-3.0-or-later
-license: GPL-3.0
+license: GPL-3.0+
 grade: stable
 adopt-info: remote-touchpad
 


### PR DESCRIPTION
Snapcraft uses SPDX 2.1 syntax[1], which allows specifying "or later" license
style by appending a `+` operator after the license expression.  Refer
Appendix IV:  SPDX License Expressions[2] for more info regarding this syntax.

[1] https://spdx.org/spdx-specification-21-web-version
[2] https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60

Refer-to: license - Snapcraft top-level metadata - doc - snapcraft.io <https://forum.snapcraft.io/t/snapcraft-top-level-metadata/8334#heading--license>  
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>

A clean build has been conducted for verification of the patch.