### PR TITLE
use relative URL for websocket

### DIFF
--- a/webdata/fn.js
+++ b/webdata/fn.js
@@ -346,8 +346,7 @@ window.addEventListener("load", function() {
     showScene(opening);
 
     ws = new WebSocket(
-        (location.protocol == "http:" ? "ws:" : "wss:") + "//" + location.hostname +
-        (location.port ? ":" + location.port : "") + "/ws"
+        String(new URL("ws", location.href)).replace(/^http/, "ws")
     );
 
     ws.onmessage = function(evt) {


### PR DESCRIPTION
This way remote-touchpad can be easily configured with a reverse proxy at any path to avoid coliision with other services.

It should work, but I need some directions on how the assetFS is build with `go generate`, because I don't know the first thing about Go.