### PR TITLE
Add support for session restore on the linux portals backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,16 @@ Supports Flatpak's RemoteDesktop portal (for Wayland), Windows and X11.
 * [Snap](https://snapcraft.io/remote-touchpad)
 * [Windows](https://github.com/Unrud/remote-touchpad/releases/latest)
 * Golang:
-  * Portal & uinput & X11: `go install -tags portal,uinput,x11 github.com/unrud/remote-touchpad@latest`
-  * Windows: `go install github.com/unrud/remote-touchpad@latest`
+  * Portal & uinput & X11:
+
+    ```sh
+    go install -tags portal,uinput,x11 github.com/unrud/remote-touchpad@latest
+    ```
+  * Windows:
+
+    ```sh
+    go install github.com/unrud/remote-touchpad@latest
+    ```
 
 ## Screenshots
 

--- a/inputcontrol/controller.go
+++ b/inputcontrol/controller.go
@@ -55,14 +55,14 @@ const (
 
 type ControllerInfo struct {
 	Name string
-	Init func() (Controller, error)
+	Init func(bool) (Controller, error)
 
 	priority int
 }
 
 var Controllers []ControllerInfo
 
-func RegisterController(name string, init func() (Controller, error), priority int) {
+func RegisterController(name string, init func(bool) (Controller, error), priority int) {
 	Controllers = append(Controllers, ControllerInfo{name, init, priority})
 	sort.SliceStable(Controllers, func(i, j int) bool {
 		return Controllers[i].priority < Controllers[j].priority

--- a/inputcontrol/controller_null.go
+++ b/inputcontrol/controller_null.go
@@ -31,7 +31,7 @@ func init() {
 	RegisterController("null", InitNullController, 1000)
 }
 
-func InitNullController() (Controller, error) {
+func InitNullController(saveRestoreToken bool) (Controller, error) {
 	return &nullController{}, nil
 }
 

--- a/inputcontrol/controller_uinput.go
+++ b/inputcontrol/controller_uinput.go
@@ -43,7 +43,7 @@ func init() {
 	RegisterController("uinput", InitUinputController, 10)
 }
 
-func InitUinputController() (Controller, error) {
+func InitUinputController(saveRestoreToken bool) (Controller, error) {
 	keymapName, keymapSet := os.LookupEnv("REMOTE_TOUCHPAD_UINPUT_KEYMAP")
 	if !keymapSet {
 		keymapName = "defkeymap"

--- a/inputcontrol/controller_windows.go
+++ b/inputcontrol/controller_windows.go
@@ -95,7 +95,7 @@ func init() {
 	RegisterController("Windows", InitWindowsController, 0)
 }
 
-func InitWindowsController() (Controller, error) {
+func InitWindowsController(saveRestoreToken bool) (Controller, error) {
 	p := &windowsController{}
 	if err := sendInputProc.Find(); err != nil {
 		return nil, &UnsupportedPlatformError{err}

--- a/inputcontrol/controller_x11.go
+++ b/inputcontrol/controller_x11.go
@@ -59,7 +59,7 @@ func init() {
 	RegisterController("X11", InitX11Controller, 0)
 }
 
-func InitX11Controller() (Controller, error) {
+func InitX11Controller(saveRestoreToken bool) (Controller, error) {
 	display := C.XOpenDisplay(nil)
 	if display == nil {
 		return nil, &UnsupportedPlatformError{

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func secureRandBase64(length int) string {
 func main() {
 	terminal.SetTitle(prettyAppName)
 	var bind, certFile, keyFile, secret string
-	var showVersion bool
+	var showVersion, savePlaintextRestoreToken bool
 	var config config
 	flag.BoolVar(&showVersion, "version", false, "show program's version number and exit")
 	flag.StringVar(&bind, "bind", defaultBind, "bind server to [HOSTNAME]:PORT")
@@ -164,6 +164,7 @@ func main() {
 	flag.Float64Var(&config.ScrollSpeed, "scroll-speed", 1, "scroll speed multiplier")
 	flag.Float64Var(&config.MouseMoveSpeed, "mouse-move-speed", 1, "mouse move speed multiplier")
 	flag.Float64Var(&config.MouseScrollSpeed, "mouse-scroll-speed", 1, "mouse scroll speed multiplier")
+	flag.BoolVar(&savePlaintextRestoreToken, "save-plaintext-restore-token", false, "save a restore token in plaintext in order to avoid the confirmation dialogue that appears with some implementations of the portals backend on wayland on linux from appearing on the next run of remote-touchpad")
 	flag.Parse()
 	if showVersion {
 		fmt.Println(version)
@@ -188,7 +189,7 @@ func main() {
 	for _, controllerInfo := range inputcontrol.Controllers {
 		controllerName = controllerInfo.Name
 		var err error
-		controller, err = controllerInfo.Init()
+		controller, err = controllerInfo.Init(savePlaintextRestoreToken)
 		if err == nil {
 			break
 		} else {


### PR DESCRIPTION
This means that for autostart usecases, the user no longer has to manually click on the "Allow remote interaction" checkbox for some portals backend implementations. I have not tested if the use of `os.UserCacheDir()` works on flatpak or snap, because I cannot build the flatpak from source, and have not bothered for the snap (maybe a note on how to build these from source in the readme could be helpful?). Depending on what OP means in #77, this could also fix that issue.